### PR TITLE
ci: run checks on develop, pin actions to SHA, add npm provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, develop]
   push:
-    branches: [master]
+    branches: [master, develop]
 
 permissions:
   contents: read
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           cache: pnpm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4.2.0
+        uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
@@ -52,13 +52,13 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           if [[ "$VERSION" == *-* ]]; then
             PRERELEASE_TAG=$(node -p "require('./package.json').version.split('-')[1].split('.')[0]")
-            npm publish --tag "$PRERELEASE_TAG"
+            npm publish --provenance --tag "$PRERELEASE_TAG"
           else
-            npm publish
+            npm publish --provenance
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2.5.0
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: ${{ github.ref_name }}
           body_path: RELEASE.md


### PR DESCRIPTION
I noticed a few things going through the CI/publish workflows and figured I'd bundle the low-risk ones into one PR since they all touch the same two files:

- `ci.yml` was only triggering on `master`. Since the repo branches `feat/*`/`fix/*` off `develop`, PRs into `develop` were merging with zero lint/typecheck/test check. Added `develop` to both `pull_request` and `push` triggers.
- Every `uses:` in both workflows referenced a mutable version tag instead of a pinned commit SHA. Pinned `actions/checkout`, `pnpm/action-setup`, `actions/setup-node`, and `softprops/action-gh-release` to their current SHAs (with the version kept as a comment).
- `publish.yml` runs `npm publish` without `--provenance`, even though it already has `id-token: write` for trusted publishing — added the flag to both the normal and prerelease publish paths.

Closes #65, closes #68, closes #69.