### PR TITLE
ci: add Dependabot config for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
I checked and there was no `.github/dependabot.yml` in this repo, so dependency updates (including security patches) were fully manual. Added daily checks for both `npm` and `github-actions` ecosystems, with a 7-day cooldown on newly published versions so a just-published (possibly malicious/unstable) release doesn't get proposed immediately.

Closes #66.