### PR TITLE
fix: don't log raw command args on rejection

### DIFF
--- a/src/runtime/server/controllers/command-export.controller.ts
+++ b/src/runtime/server/controllers/command-export.controller.ts
@@ -89,7 +89,7 @@ export class CommandExportController implements InternalCommandsExports {
           playerId: player.clientID,
           playerName: player.name,
           accountID: player.accountID,
-          args: args,
+          argCount: args.length,
         })
         return
       }


### PR DESCRIPTION
I noticed `onCommandReceived` logs raw player-typed command args verbatim when a command gets rejected — that could capture sensitive text a player typed, like a token or password pasted into a command by accident.

Replaced `args: args` with `argCount: args.length` in the rejection log, same signal for debugging without the raw content.

`pnpm test`, `pnpm typecheck`, and `pnpm check` all pass.

Closes #75.