### PR TITLE
fix: replace O(n) history shift with ring buffer, prevent pendingEvents leak

### DIFF
--- a/src/runtime/server/devmode/event-interceptor.service.ts
+++ b/src/runtime/server/devmode/event-interceptor.service.ts
@@ -3,6 +3,48 @@ import { IDevModeInterceptor } from './contracts/IDevModeInterceptor'
 import { DevEvent, InterceptorOptions } from './types'
 
 /**
+ * Fixed-capacity circular buffer. Unlike `Array.push()` + `Array.shift()`,
+ * eviction of the oldest entry is O(1) instead of O(n).
+ */
+class RingBuffer<T> {
+  private buffer: T[] = []
+  private start = 0
+  private capacity: number
+
+  constructor(capacity: number) {
+    this.capacity = Math.max(1, capacity)
+  }
+
+  push(item: T): void {
+    if (this.buffer.length < this.capacity) {
+      this.buffer.push(item)
+      return
+    }
+    this.buffer[this.start] = item
+    this.start = (this.start + 1) % this.capacity
+  }
+
+  toArray(): T[] {
+    if (this.buffer.length < this.capacity) return [...this.buffer]
+    return [...this.buffer.slice(this.start), ...this.buffer.slice(0, this.start)]
+  }
+
+  clear(): void {
+    this.buffer = []
+    this.start = 0
+  }
+
+  setCapacity(capacity: number): void {
+    const newCapacity = Math.max(1, capacity)
+    if (newCapacity === this.capacity) return
+    const current = this.toArray()
+    this.capacity = newCapacity
+    this.buffer = current.slice(-newCapacity)
+    this.start = 0
+  }
+}
+
+/**
  * Implementation of the DevMode event interceptor.
  *
  * Captures and records all framework events for debugging and analysis.
@@ -10,8 +52,10 @@ import { DevEvent, InterceptorOptions } from './types'
  */
 @injectable()
 export class EventInterceptorService extends IDevModeInterceptor {
+  private static readonly MAX_PENDING_AGE_MS = 5 * 60 * 1000
+
   private enabled = false
-  private history: DevEvent[] = []
+  private historyBuffer: RingBuffer<DevEvent>
   private pendingEvents = new Map<string, DevEvent>()
   private options: InterceptorOptions
   private eventCounter = 0
@@ -24,6 +68,7 @@ export class EventInterceptorService extends IDevModeInterceptor {
       recordHistory: true,
       maxHistorySize: 1000,
     }
+    this.historyBuffer = new RingBuffer(this.options.maxHistorySize)
   }
 
   /**
@@ -32,6 +77,7 @@ export class EventInterceptorService extends IDevModeInterceptor {
   configure(options: Partial<InterceptorOptions>): void {
     this.options = { ...this.options, ...options }
     this.enabled = this.options.enabled
+    this.historyBuffer.setCapacity(this.options.maxHistorySize)
   }
 
   onEventBefore(event: Omit<DevEvent, 'result' | 'duration'>): void {
@@ -66,11 +112,11 @@ export class EventInterceptorService extends IDevModeInterceptor {
   }
 
   getEventHistory(): DevEvent[] {
-    return [...this.history]
+    return this.historyBuffer.toArray()
   }
 
   clearHistory(): void {
-    this.history = []
+    this.historyBuffer.clear()
   }
 
   setEnabled(enabled: boolean): void {
@@ -107,6 +153,7 @@ export class EventInterceptorService extends IDevModeInterceptor {
       args,
       source,
     }
+    this.prunePendingEvents()
     this.pendingEvents.set(id, event)
     this.onEventBefore(event)
     return id
@@ -126,6 +173,7 @@ export class EventInterceptorService extends IDevModeInterceptor {
       args,
       source,
     }
+    this.prunePendingEvents()
     this.pendingEvents.set(id, event)
     this.onEventBefore(event)
     return id
@@ -144,6 +192,7 @@ export class EventInterceptorService extends IDevModeInterceptor {
       direction: 'in',
       args,
     }
+    this.prunePendingEvents()
     this.pendingEvents.set(id, event)
     this.onEventBefore(event)
     return id
@@ -192,14 +241,16 @@ export class EventInterceptorService extends IDevModeInterceptor {
    * Gets events filtered by type.
    */
   getEventsByType(type: DevEvent['type']): DevEvent[] {
-    return this.history.filter((e) => e.type === type)
+    return this.historyBuffer.toArray().filter((e) => e.type === type)
   }
 
   /**
    * Gets events within a time range.
    */
   getEventsByTimeRange(startTime: number, endTime: number): DevEvent[] {
-    return this.history.filter((e) => e.timestamp >= startTime && e.timestamp <= endTime)
+    return this.historyBuffer
+      .toArray()
+      .filter((e) => e.timestamp >= startTime && e.timestamp <= endTime)
   }
 
   /**
@@ -216,7 +267,8 @@ export class EventInterceptorService extends IDevModeInterceptor {
     let durationCount = 0
     let errors = 0
 
-    for (const event of this.history) {
+    const history = this.historyBuffer.toArray()
+    for (const event of history) {
       byType[event.type] = (byType[event.type] || 0) + 1
       if (event.duration !== undefined) {
         totalDuration += event.duration
@@ -228,7 +280,7 @@ export class EventInterceptorService extends IDevModeInterceptor {
     }
 
     return {
-      total: this.history.length,
+      total: history.length,
       byType,
       avgDuration: durationCount > 0 ? totalDuration / durationCount : 0,
       errors,
@@ -240,9 +292,20 @@ export class EventInterceptorService extends IDevModeInterceptor {
   }
 
   private addToHistory(event: DevEvent): void {
-    this.history.push(event)
-    if (this.history.length > this.options.maxHistorySize) {
-      this.history.shift()
+    this.historyBuffer.push(event)
+  }
+
+  /**
+   * Drops pending events that never reached `completeEvent`/`failEvent` (e.g. because
+   * the surrounding call threw before either was invoked), so `pendingEvents` can't
+   * grow unbounded over the lifetime of a long-running server.
+   */
+  private prunePendingEvents(): void {
+    const now = Date.now()
+    for (const [id, event] of this.pendingEvents) {
+      if (now - event.timestamp > EventInterceptorService.MAX_PENDING_AGE_MS) {
+        this.pendingEvents.delete(id)
+      }
     }
   }
 

--- a/tests/unit/server/devmode/event-interceptor.service.test.ts
+++ b/tests/unit/server/devmode/event-interceptor.service.test.ts
@@ -1,0 +1,122 @@
+import 'reflect-metadata'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EventInterceptorService } from '../../../../src/runtime/server/devmode/event-interceptor.service'
+
+describe('EventInterceptorService', () => {
+  let interceptor: EventInterceptorService
+
+  beforeEach(() => {
+    interceptor = new EventInterceptorService()
+    interceptor.configure({ enabled: true, recordHistory: true, maxHistorySize: 1000 })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('history ring buffer', () => {
+    it('keeps only the most recent maxHistorySize events, in chronological order', () => {
+      interceptor.configure({ maxHistorySize: 3 })
+
+      for (let i = 0; i < 5; i++) {
+        const id = interceptor.recordCommand(`cmd-${i}`, [])
+        interceptor.completeEvent(id, 'ok', Date.now())
+      }
+
+      const history = interceptor.getEventHistory()
+      expect(history).toHaveLength(3)
+      expect(history.map((e) => e.name)).toEqual(['cmd-2', 'cmd-3', 'cmd-4'])
+    })
+
+    it('preserves order across capacity shrink via configure()', () => {
+      for (let i = 0; i < 4; i++) {
+        const id = interceptor.recordCommand(`cmd-${i}`, [])
+        interceptor.completeEvent(id, 'ok', Date.now())
+      }
+
+      interceptor.configure({ maxHistorySize: 2 })
+
+      expect(interceptor.getEventHistory().map((e) => e.name)).toEqual(['cmd-2', 'cmd-3'])
+    })
+
+    it('clearHistory empties the buffer', () => {
+      const id = interceptor.recordCommand('cmd', [])
+      interceptor.completeEvent(id, 'ok', Date.now())
+
+      interceptor.clearHistory()
+
+      expect(interceptor.getEventHistory()).toEqual([])
+    })
+  })
+
+  describe('completeEvent / failEvent', () => {
+    it('moves a pending event to history with its result', () => {
+      const id = interceptor.recordCommand('heal', ['10'])
+      interceptor.completeEvent(id, { healed: true }, Date.now())
+
+      const [event] = interceptor.getEventHistory()
+      expect(event.result).toEqual({ healed: true })
+      expect(event.duration).toBeGreaterThanOrEqual(0)
+    })
+
+    it('moves a pending event to history with its error', () => {
+      const id = interceptor.recordCommand('heal', ['10'])
+      interceptor.failEvent(id, 'boom', Date.now())
+
+      const [event] = interceptor.getEventHistory()
+      expect(event.error).toBe('boom')
+    })
+
+    it('is a no-op for an unknown event id', () => {
+      expect(() => interceptor.completeEvent('nope', 'ok', Date.now())).not.toThrow()
+      expect(interceptor.getEventHistory()).toEqual([])
+    })
+  })
+
+  describe('pending event pruning', () => {
+    it('drops pending events that never complete before they can leak forever', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(0)
+
+      const staleId = interceptor.recordCommand('never-completed', [])
+
+      // Past the 5-minute staleness window.
+      vi.setSystemTime(5 * 60 * 1000 + 1)
+
+      // Recording a new event triggers the sweep of stale pending entries.
+      const freshId = interceptor.recordCommand('fresh', [])
+
+      // The stale entry is gone, so completing it now is a no-op.
+      interceptor.completeEvent(staleId, 'late', Date.now())
+      interceptor.completeEvent(freshId, 'ok', Date.now())
+
+      const history = interceptor.getEventHistory()
+      expect(history).toHaveLength(1)
+      expect(history[0].name).toBe('fresh')
+    })
+  })
+
+  describe('queries', () => {
+    it('getEventsByType filters by type', () => {
+      const cmdId = interceptor.recordCommand('cmd', [])
+      interceptor.completeEvent(cmdId, 'ok', Date.now())
+      const exportId = interceptor.recordExport('export', [])
+      interceptor.completeEvent(exportId, 'ok', Date.now())
+
+      expect(interceptor.getEventsByType('command')).toHaveLength(1)
+      expect(interceptor.getEventsByType('export')).toHaveLength(1)
+    })
+
+    it('getStatistics aggregates totals, errors and average duration', () => {
+      const okId = interceptor.recordCommand('ok-cmd', [])
+      interceptor.completeEvent(okId, 'ok', Date.now())
+      const failId = interceptor.recordCommand('fail-cmd', [])
+      interceptor.failEvent(failId, 'boom', Date.now())
+
+      const stats = interceptor.getStatistics()
+      expect(stats.total).toBe(2)
+      expect(stats.errors).toBe(1)
+      expect(stats.byType.command).toBe(2)
+    })
+  })
+})


### PR DESCRIPTION
While reading `EventInterceptorService` I noticed two things:

- `addToHistory` did `history.push()` + `history.shift()` once `maxHistorySize` was exceeded — `Array.shift()` is O(n) per call, which doesn't match the "circular buffer" doc comment and would degrade interceptor throughput under sustained event load.
- `pendingEvents` entries are only removed by `completeEvent`/`failEvent`. If whatever calls those throws before reaching them, the entry leaks for the lifetime of the process.

Changes:
- Added a small `RingBuffer<T>` (fixed-capacity circular array) and switched `history` to it — O(1) push instead of O(n) shift, same public behavior (`getEventHistory()`/`getEventsByType()`/etc. still return chronological order). It also handles `configure()` shrinking `maxHistorySize` at runtime by keeping the most recent entries.
- Added a staleness sweep (`prunePendingEvents`, 5 minute threshold) that runs on every new `recordNetEvent`/`recordCommand`/`recordExport` call, so entries that never reach `completeEvent`/`failEvent` get dropped instead of accumulating forever.

There wasn't an existing test file for this service, so I added one covering the ring buffer (capacity eviction, ordering, shrink-via-configure), `completeEvent`/`failEvent`, the pruning behavior (via fake timers), and the query/stats methods.

`pnpm test` (564/564), `pnpm typecheck`, and `pnpm check` all pass.

Closes #76.